### PR TITLE
Fix cleanup batching + reduce DB load on high-traffic sites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wp-rocket-smart-preload",
-    "version": "1.0.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wp-rocket-smart-preload",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "license": "ISC",
             "devDependencies": {
                 "esbuild": "^0.24.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-rocket-smart-preload",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Smart preload for WP Rocket",
     "type": "module",
     "scripts": {

--- a/src/wp-rocket-smart-preload.php
+++ b/src/wp-rocket-smart-preload.php
@@ -186,6 +186,107 @@ add_action('plugins_loaded', function () {
         add_action('admin_notices', 'rsp_wp_rocket_inactive_custom_admin_notice');
     }
 });
+
+/**
+ * Check whether the last_visit index exists on the visits table.
+ *
+ * @return bool
+ */
+function rsp_last_visit_index_exists()
+{
+    global $wpdb;
+    $table_name = RSP_PLUGIN_TABLE;
+
+    $count = $wpdb->get_var(
+        $wpdb->prepare(
+            "SELECT COUNT(1)
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                    AND table_name = %s
+                    AND column_name = 'last_visit'",
+            $table_name
+        )
+    );
+
+    return (int) $count > 0;
+}
+
+function rsp_maybe_show_db_update_notice()
+{
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+
+    $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+    if ($screen && !in_array($screen->id, ['plugins', 'settings_page_wp-rocket-smart-preload'], true)) {
+        return;
+    }
+
+    // Show result notice after a DB update attempt.
+    if (isset($_GET['rsp_db_update'])) {
+        $status = sanitize_text_field(wp_unslash($_GET['rsp_db_update']));
+        if ($status === 'success') {
+            echo '<div class="notice notice-success is-dismissible"><p><strong>WP Rocket - Smart Preload:</strong> Database update completed.</p></div>';
+        } elseif ($status === 'already') {
+            echo '<div class="notice notice-info is-dismissible"><p><strong>WP Rocket - Smart Preload:</strong> Database is already up to date.</p></div>';
+        } elseif ($status === 'error') {
+            echo '<div class="notice notice-error is-dismissible"><p><strong>WP Rocket - Smart Preload:</strong> Database update failed. Please try again during low traffic or run the update via WP-CLI/your database tool.</p></div>';
+        }
+    }
+
+    if (rsp_last_visit_index_exists()) {
+        return;
+    }
+
+    $run_url = wp_nonce_url(
+        admin_url('admin-post.php?action=rsp_add_last_visit_index'),
+        'rsp_add_last_visit_index'
+    );
+
+    echo '<div class="notice notice-warning"><p><strong>WP Rocket - Smart Preload:</strong> A database optimization is recommended for high-traffic sites. Add an index on <code>last_visit</code> to keep cleanup and sitemap generation fast.</p>'
+        . '<p><a class="button button-primary" href="' . esc_url($run_url) . '">Add index now</a></p>'
+        . '<p><em>Note:</em> On large tables this can take time and may lock the visits table. Run during low traffic.</p></div>';
+}
+
+add_action('admin_notices', 'rsp_maybe_show_db_update_notice');
+
+function rsp_handle_add_last_visit_index()
+{
+    if (!current_user_can('manage_options')) {
+        wp_die('Forbidden');
+    }
+    check_admin_referer('rsp_add_last_visit_index');
+
+    $redirect_url = wp_get_referer();
+    if (empty($redirect_url)) {
+        $redirect_url = admin_url('plugins.php');
+    }
+    $redirect_url = remove_query_arg('rsp_db_update', $redirect_url);
+
+    if (rsp_last_visit_index_exists()) {
+        wp_safe_redirect(add_query_arg('rsp_db_update', 'already', $redirect_url));
+        exit;
+    }
+
+    global $wpdb;
+    $table_name = RSP_PLUGIN_TABLE;
+    $result = $wpdb->query("ALTER TABLE `$table_name` ADD INDEX `last_visit` (`last_visit`)");
+
+    if (false === $result) {
+        // If the index was created concurrently, treat it as already updated.
+        if (stripos((string) $wpdb->last_error, 'Duplicate key name') !== false) {
+            wp_safe_redirect(add_query_arg('rsp_db_update', 'already', $redirect_url));
+            exit;
+        }
+        wp_safe_redirect(add_query_arg('rsp_db_update', 'error', $redirect_url));
+        exit;
+    }
+
+    wp_safe_redirect(add_query_arg('rsp_db_update', 'success', $redirect_url));
+    exit;
+}
+
+add_action('admin_post_rsp_add_last_visit_index', 'rsp_handle_add_last_visit_index');
 // Activation hook to create database table
 register_activation_hook(__FILE__, 'rsp_fire_activation_hook_tasks');
 /**

--- a/src/wp-rocket-smart-preload.php
+++ b/src/wp-rocket-smart-preload.php
@@ -679,7 +679,7 @@ function rsp_process_cleanup_batch()
     );
 
     // If there are more records to delete, schedule the next batch, until $affected_rows is 0
-    if ($affected_rows > 0 && !wp_next_scheduled('rsp_batch_cleanup_task')) {
+    if ($affected_rows > 0) {
         wp_schedule_single_event(time() + 60, 'rsp_batch_cleanup_task');
     }
 }

--- a/src/wp-rocket-smart-preload.php
+++ b/src/wp-rocket-smart-preload.php
@@ -211,6 +211,7 @@ function rsp_fire_activation_hook_tasks()
         last_visit TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         visit_count BIGINT UNSIGNED DEFAULT 1,
         PRIMARY KEY (id),
+        KEY last_visit (last_visit),
         UNIQUE KEY unique_visit (page_url(255), user_ip)
     ) $charset_collate;";
 
@@ -352,7 +353,7 @@ function rsp_record_visit()
 {
     global $wpdb;
     // Bail if it's a bot
-    if (is_bot($_SERVER['HTTP_USER_AGENT'])) {
+    if (is_bot($_SERVER['HTTP_USER_AGENT'] ?? '')) {
         wp_send_json_error('Skipping bot visit');
     }
     // Verify nonce
@@ -371,39 +372,35 @@ function rsp_record_visit()
     $user_ip = rsp_get_user_ip();
     $table_name = RSP_PLUGIN_TABLE;
 
-    // Check if a record exists
-    $existing_visit = $wpdb->get_row(
-        $wpdb->prepare("SELECT * FROM $table_name WHERE page_url = %s AND user_ip = %s", $page_url, $user_ip)
+    // Single-statement upsert to reduce DB load (vs. SELECT + UPDATE/INSERT).
+    // Returns affected_rows: 1 (insert), 2 (updated), 0 (duplicate but no-op => too early).
+    $deactivate_ip_protection = (bool) intval(apply_filters('rsp_deactivate_ip_protection', get_option('rsp_deactivate_ip_protection', 0)));
+    $now_mysql = current_time('mysql');
+
+    $query = $wpdb->prepare(
+        "INSERT INTO $table_name (page_url, user_ip, last_visit, visit_count)
+            VALUES (%s, %s, %s, 1)
+            ON DUPLICATE KEY UPDATE
+                visit_count = visit_count + IF(%d = 1 OR TIMESTAMPDIFF(SECOND, last_visit, %s) > %d, 1, 0),
+                last_visit = IF(%d = 1 OR TIMESTAMPDIFF(SECOND, last_visit, %s) > %d, %s, last_visit)",
+        $page_url,
+        $user_ip,
+        $now_mysql,
+        $deactivate_ip_protection ? 1 : 0,
+        $now_mysql,
+        (int) RSP_IP_PROTECTION_TIME_THRESHOLD,
+        $deactivate_ip_protection ? 1 : 0,
+        $now_mysql,
+        (int) RSP_IP_PROTECTION_TIME_THRESHOLD,
+        $now_mysql
     );
 
-    if ($existing_visit) {
-        $last_visit_time = strtotime($existing_visit->last_visit);
-        $current_time = current_time('timestamp');
-        $deactivate_ip_protection = (bool) intval(apply_filters('rsp_deactivate_ip_protection', get_option('rsp_deactivate_ip_protection', 0)));
-        // Update last visit timestamp and increment visit count if over an hour since last visit (or if IP protection is deactivated)
-        if ($deactivate_ip_protection || (($current_time - $last_visit_time) > RSP_IP_PROTECTION_TIME_THRESHOLD)) {
-            $wpdb->update(
-                $table_name,
-                [
-                    'last_visit' => current_time('mysql'),
-                    'visit_count' => $existing_visit->visit_count + 1
-                ],
-                ['id' => $existing_visit->id]
-            );
-        } else {
-            wp_send_json_error('Visit not recorded. Too early to record a new visit from the same IP.');
-        }
-    } else {
-        // Insert new visit record
-        $wpdb->insert(
-            $table_name,
-            [
-                'page_url' => $page_url,
-                'user_ip' => $user_ip,
-                'last_visit' => current_time('mysql'),
-                'visit_count' => 1
-            ]
-        );
+    $affected_rows = $wpdb->query($query);
+    if (false === $affected_rows) {
+        wp_send_json_error('Database error');
+    }
+    if (0 === $affected_rows) {
+        wp_send_json_error('Visit not recorded. Too early to record a new visit from the same IP.');
     }
 
     wp_send_json_success('Visit recorded');
@@ -428,9 +425,24 @@ function rsp_get_most_visited($number = RSP_SITEMAP_PAGE_DEFAULT_LIMIT, $urls_on
     global $wpdb;
     $table_name = RSP_PLUGIN_TABLE;
 
+    // Limit the aggregation to the same retention window used by the cleanup task.
+    // This keeps the query bounded even if cron is delayed and old rows remain in the table.
+    $now_ts = current_time('timestamp');
+    $threshold_ts = strtotime(RSP_CLEANUP_THREASHOLD_TIME, $now_ts);
+    if (false === $threshold_ts) {
+        $threshold_ts = strtotime('-30 days', $now_ts);
+    }
+    $threshold_date = date('Y-m-d H:i:s', $threshold_ts);
+
     $results = $wpdb->get_results(
         $wpdb->prepare(
-            "SELECT page_url, SUM(visit_count) AS total_visits FROM $table_name GROUP BY page_url ORDER BY total_visits DESC LIMIT %d",
+            "SELECT page_url, SUM(visit_count) AS total_visits
+                FROM $table_name
+                WHERE last_visit >= %s
+                GROUP BY page_url
+                ORDER BY total_visits DESC
+                LIMIT %d",
+            $threshold_date,
             intval($number)
         ),
         ARRAY_A
@@ -539,12 +551,20 @@ add_action('rsp_batch_cleanup_task', 'rsp_process_cleanup_batch');
 function rsp_process_cleanup_batch()
 {
     global $wpdb;
-    $wp_mysql_time_format = 'Y-m-d H:i:s';
-    $date = new DateTime('2025-01-25 09:30:34');
-    $date->modify(RSP_CLEANUP_THREASHOLD_TIME);
-    $threshold_date = $date->format($wp_mysql_time_format);
-    $table_name = $wpdb->prefix . 'rsp_page_visits';
-    // $threshold_date = date('Y-m-d H:i:s', strtotime(RSP_CLEANUP_THREASHOLD_TIME));
+
+    // Calculate threshold relative to "now" (WP time) instead of a fixed timestamp.
+    // This keeps the table bounded to the retention window defined by RSP_CLEANUP_THREASHOLD_TIME.
+    $now_ts = current_time('timestamp');
+    $threshold_ts = strtotime(RSP_CLEANUP_THREASHOLD_TIME, $now_ts);
+    if (false === $threshold_ts) {
+        $threshold_ts = strtotime('-30 days', $now_ts);
+        if (false === $threshold_ts) {
+            return;
+        }
+    }
+    $threshold_date = date('Y-m-d H:i:s', $threshold_ts);
+
+    $table_name = RSP_PLUGIN_TABLE;
     $batch_size = apply_filters('rsp_cleanup_batch_limit_size', RSP_CLEANUP_BATCH_DEFAULT_LIMIT);
     $batch_size = validate_positive_integer($batch_size, RSP_CLEANUP_BATCH_DEFAULT_LIMIT);
 
@@ -556,12 +576,10 @@ function rsp_process_cleanup_batch()
             $batch_size
         )
     );
-    // error_log('Deleted records: ' . $affected_rows . "\n\n", 3, ABSPATH . 'rsp_database_cleanup.log');
-    echo 'Deleted records: ' . $affected_rows . "\n\n";
 
     // If there are more records to delete, schedule the next batch, until $affected_rows is 0
-    if ($affected_rows > 0) {
-        // wp_schedule_single_event(time() + 60, 'rsp_batch_cleanup_task');
+    if ($affected_rows > 0 && !wp_next_scheduled('rsp_batch_cleanup_task')) {
+        wp_schedule_single_event(time() + 60, 'rsp_batch_cleanup_task');
     }
 }
 


### PR DESCRIPTION
Fixes #9.

### Changes
- Fix cleanup threshold calculation to be relative to "now" (was hard-coded), so old rows are actually purged.
- Re-enable iterative batch cleanup scheduling until the table is within the retention window.
- Remove cron-time output (no `echo`).
- Bound `rsp_get_most_visited()` aggregation to the same retention window (`RSP_CLEANUP_THREASHOLD_TIME`) to keep the query bounded if cron is delayed.
- Use a single-statement `INSERT ... ON DUPLICATE KEY UPDATE` for visit recording to reduce DB queries per page view and keep updates atomic.
- Add an index on `last_visit` in the table schema to speed cleanup / range queries (via `dbDelta` on activation).
- Add an admin notice + CTA to add the `last_visit` index on demand (so high-traffic sites can run it off-peak).
- Bump package version to `1.1.1`.

### Notes
- The DB update notice is shown on the Plugins screen and the plugin settings page until an index on `last_visit` exists.
- The CTA runs an `ALTER TABLE ... ADD INDEX ...` which can take time and lock writes on very large tables.

Related: #8
